### PR TITLE
option to create with body

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -38,7 +38,7 @@ func main() {
   d := url.Values{}
   d.Set("network", "192.168.11.0/24")
   d.Set("comment", "created example")
-  ref, err := ib.Network().Create(d, nil)
+  ref, err := ib.Network().Create(d, nil, nil)
   printString(ref, err)
 
   if ref != "" {

--- a/record_host.go
+++ b/record_host.go
@@ -1,12 +1,5 @@
 package infoblox
 
-import (
-  "fmt"
-  "net/url"
-  "strconv"
-  "strings"
-)
-
 // https://192.168.2.200/wapidoc/objects/record.host.html
 func (c *Client) RecordHost() *Resource {
   return &Resource{


### PR DESCRIPTION
Added json body to create method for objects that have non-string fields. Infoblox has no support for url-encoded list/struct fields and those fields have to be specified in JSON (see https://ipam.illinois.edu/wapidoc/#general-syntax-and-options)

Also removed imports from record_host because they are not used so it wouldn't compile otherwise.
