### PR TITLE
infoblox session cookie support

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -8,8 +8,8 @@ import (
 )
 
 func main() {
-	// URL, username, password, sslVerify
-	ib := infoblox.NewClient("https://192.168.2.200/", "admin", "infoblox", false)
+	// URL, username, password, sslVerify, useCookies
+	ib := infoblox.NewClient("https://192.168.2.200/", "admin", "infoblox", false, false)
 
 	// All networks
 	printList(ib.Network().All(nil))

--- a/infoblox.go
+++ b/infoblox.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"strings"
+
+	"golang.org/x/net/publicsuffix"
 )
 
 var (
@@ -23,6 +26,7 @@ type Client struct {
 	Password   string
 	Username   string
 	HttpClient *http.Client
+	UseCookies bool
 }
 
 // Creates a new Infoblox client with the supplied user/pass configuration.
@@ -32,7 +36,11 @@ type Client struct {
 //
 // When using a proxy, disable TLS certificate verification with the following:
 //    sslVerify = false
-func NewClient(host, username, password string, sslVerify bool) *Client {
+//
+// To save and re-use infoblox session cookies, set useCookies = true
+// NOTE: The infoblox cookie uses a comma separated string, and requires golang 1.3+ to be correctly stored.
+//
+func NewClient(host, username, password string, sslVerify, useCookies bool) *Client {
 	var (
 		req, _    = http.NewRequest("GET", host, nil)
 		proxy, _  = http.ProxyFromEnvironment(req)
@@ -51,29 +59,80 @@ func NewClient(host, username, password string, sslVerify bool) *Client {
 	if proxy != nil {
 		transport.Proxy = http.ProxyURL(proxy)
 	}
-	return &Client{
+
+	client := &Client{
 		Host: host,
 		HttpClient: &http.Client{
 			Transport: transport,
 		},
-		Username: username,
-		Password: password,
+		Username:   username,
+		Password:   password,
+		UseCookies: useCookies,
 	}
+	if useCookies {
+		options := cookiejar.Options{
+			PublicSuffixList: publicsuffix.List,
+		}
+		jar, _ := cookiejar.New(&options)
+		client.HttpClient.Jar = jar
+	}
+	return client
+
 }
 
 // Sends a HTTP request through this instance's HTTP client.
-func (c *Client) SendRequest(req *http.Request) (resp *APIResponse, err error) {
-	u := req.URL.String()
-	if !strings.HasPrefix(u, "http") {
-		u = fmt.Sprintf("%v%v", c.Host, u)
-		req.URL, err = url.Parse(u)
-		if err != nil {
-			return
-		}
+// Uses cookies if specified, re-creating the request and falling back to basic auth if a cookie is not present
+func (c *Client) SendRequest(method, urlStr, body string, head map[string]string) (resp *APIResponse, err error) {
+	log.Printf("%s %s  payload: %s\n", method, urlStr, body)
+	req, err := c.buildRequest(method, urlStr, body, head)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating request: %v\n", err)
 	}
-	req.SetBasicAuth(c.Username, c.Password)
 	var r *http.Response
+	if !c.UseCookies {
+		// Go right to basic auth if we arent using cookies
+		req.SetBasicAuth(c.Username, c.Password)
+	}
+
 	r, err = c.HttpClient.Do(req)
+	if r.StatusCode == 401 && c.UseCookies { // don't bother re-sending if we aren't using cookies
+		log.Printf("Re-sending request with basic auth after 401")
+		// Re-build request
+		req, err = c.buildRequest(method, urlStr, body, head)
+		if err != nil {
+			return nil, fmt.Errorf("Error re-creating request: %v\n", err)
+		}
+		// Set basic auth
+		req.SetBasicAuth(c.Username, c.Password)
+		// Resend request
+		r, err = c.HttpClient.Do(req)
+	}
 	resp = (*APIResponse)(r)
 	return
+}
+
+// build a new http request from this client
+func (c *Client) buildRequest(method, urlStr, body string, head map[string]string) (*http.Request, error) {
+	var req *http.Request
+	var err error
+	if body == "" {
+		req, err = http.NewRequest(method, urlStr, nil)
+	} else {
+		b := strings.NewReader(body)
+		req, err = http.NewRequest(method, urlStr, b)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasPrefix(urlStr, "http") {
+		u := fmt.Sprintf("%v%v", c.Host, urlStr)
+		req.URL, err = url.Parse(u)
+		if err != nil {
+			return nil, err
+		}
+	}
+	for k, v := range head {
+		req.Header.Set(k, v)
+	}
+	return req, err
 }

--- a/object.go
+++ b/object.go
@@ -2,10 +2,7 @@ package infoblox
 
 import (
   "fmt"
-  "log"
-  "net/http"
   "net/url"
-  "strings"
 )
 
 //Resource represents a WAPI object
@@ -17,13 +14,7 @@ type Object struct {
 func (o Object) Get(opts *Options) (map[string]interface{}, error) {
   q := o.r.getQuery(opts, []Condition{}, url.Values{})
 
-  log.Printf("GET %s\n", o.objectURI()+"?"+q.Encode())
-  req, err := http.NewRequest("GET", o.objectURI()+"?"+q.Encode(), nil)
-  if err != nil {
-    return nil, fmt.Errorf("Error creating request: %v\n", err)
-  }
-
-  resp, err := o.r.conn.SendRequest(req)
+  resp, err := o.r.conn.SendRequest("GET", o.objectURI()+"?"+q.Encode(), "", nil)
   if err != nil {
     return nil, fmt.Errorf("Error sending request: %v\n", err)
   }
@@ -42,14 +33,7 @@ func (o Object) Update(data url.Values, opts *Options) (string, error) {
   q := o.r.getQuery(opts, []Condition{}, data)
   q.Set("_return_fields", "") //Force object response
 
-  log.Printf("PUT %s\n", o.objectURI()+"?"+q.Encode())
-  req, err := http.NewRequest("PUT", o.objectURI(), strings.NewReader(q.Encode()))
-  if err != nil {
-    return "", fmt.Errorf("Error creating request: %v\n", err)
-  }
-  req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-  resp, err := o.r.conn.SendRequest(req)
+  resp, err := o.r.conn.SendRequest("PUT", o.objectURI(), q.Encode(), map[string]string{"Content-Type": "application/x-www-form-urlencoded"})
   if err != nil {
     return "", fmt.Errorf("Error sending request: %v\n", err)
   }
@@ -67,13 +51,7 @@ func (o Object) Update(data url.Values, opts *Options) (string, error) {
 func (o Object) Delete(opts *Options) error {
   q := o.r.getQuery(opts, []Condition{}, url.Values{})
 
-  log.Printf("DELETE %s\n", o.objectURI()+"?"+q.Encode())
-  req, err := http.NewRequest("DELETE", o.objectURI()+"?"+q.Encode(), nil)
-  if err != nil {
-    return fmt.Errorf("Error creating request: %v\n", err)
-  }
-
-  resp, err := o.r.conn.SendRequest(req)
+  resp, err := o.r.conn.SendRequest("DELETE", o.objectURI()+"?"+q.Encode(), "", nil)
   if err != nil {
     return fmt.Errorf("Error sending request: %v\n", err)
   }
@@ -91,14 +69,7 @@ func (o Object) Delete(opts *Options) error {
 func (o Object) FunctionCall(functionName string, inputFields url.Values) (map[string]interface{}, error) {
   inputFields.Set("_function", functionName)
 
-  log.Printf("POST %s\n", o.objectURI()+"?"+inputFields.Encode())
-  req, err := http.NewRequest("POST", o.objectURI(), strings.NewReader(inputFields.Encode()))
-  if err != nil {
-    return nil, fmt.Errorf("Error creating request: %v\n", err)
-  }
-  req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-  resp, err := o.r.conn.SendRequest(req)
+  resp, err := o.r.conn.SendRequest("POST", o.objectURI(), inputFields.Encode(), map[string]string{"Content-Type": "application/x-www-form-urlencoded"})
   if err != nil {
     return nil, fmt.Errorf("Error sending request: %v\n", err)
   }


### PR DESCRIPTION
Adds support for saving cookies that Infoblox returns and using them for subsequent requests. Falls back on basic auth when a 401 is received because of a nonexistent or expired cookie.
