### PR TITLE
objects field is an array of strings

### DIFF
--- a/ipv4address.go
+++ b/ipv4address.go
@@ -18,7 +18,7 @@ type Ipv4addressObject struct {
 	Names                []string `json:"names,omitempty"`
 	Network              string   `json:"network,omitempty"`
 	NetworkView          string   `json:"network_view,omitempty"`
-	Objects              string   `json:"objects,omitempty"`
+	Objects              []string `json:"objects,omitempty"`
 	Status               string   `json:"status,omitempty"`
 	Types                []string `json:"types,omitempty"`
 	Usage                []string `json:"usage,omitempty"`

--- a/record_host.go
+++ b/record_host.go
@@ -52,7 +52,7 @@ func (c *Client) GetRecordHost(ref string) (*RecordHostObject, error) {
 func (c *Client) FindRecordHost(name string) ([]RecordHostObject, error) {
 	field := "name"
 	conditions := []Condition{Condition{Field: &field, Value: name}}
-	resp, err := c.Ipv4address().find(conditions, nil)
+	resp, err := c.RecordHost().find(conditions, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The return field "objects" for ipv4address is an array of strings.
