### PR TITLE
ignoring object in json breaks Ref() function

### DIFF
--- a/ipv4address.go
+++ b/ipv4address.go
@@ -9,7 +9,7 @@ func (c *Client) Ipv4address() *Resource {
 }
 
 type Ipv4addressObject struct {
-	Object               `json:"-"`
+	Object
 	DHCPClientIdentifier string   `json:"dhcp_client_identifier,omitempty"`
 	IPAddress            string   `json:"ip_address,omitempty"`
 	IsConflict           bool     `json:"is_conflict,omitempty"`

--- a/network.go
+++ b/network.go
@@ -16,7 +16,7 @@ func (c *Client) Network() *Resource {
 }
 
 type NetworkObject struct {
-	Object      `json:"-"`
+	Object
 	Comment     string  `json:"comment,omitempty"`
 	Network     string  `json:"network,omitempty"`
 	NetworkView string  `json:"network_view,omitempty"`

--- a/record_host.go
+++ b/record_host.go
@@ -11,7 +11,7 @@ func (c *Client) RecordHost() *Resource {
 }
 
 type RecordHostObject struct {
-	Object    `json:"-"`
+	Object
 	Ipv4Addrs []HostIpv4Addr `json:"ipv4addrs,omitempty"`
 	//Ipv6Addrs string `json:"ipv6addrs,omitempty"`
 	Name string `json:"name,omitempty"`


### PR DESCRIPTION
Object can't be ignored in the json field tags, because the _ref field needs to be populated.
