### PR TITLE
export ref field so that it can be unmarshalled

### DIFF
--- a/ipv4address.go
+++ b/ipv4address.go
@@ -28,8 +28,8 @@ type Ipv4addressObject struct {
 func (c *Client) Ipv4addressObject(ref string) *Ipv4addressObject {
 	ip := Ipv4addressObject{}
 	ip.Object = Object{
-		_ref: ref,
-		r:    c.Ipv4address(),
+		Ref: ref,
+		r:   c.Ipv4address(),
 	}
 	return &ip
 }

--- a/network.go
+++ b/network.go
@@ -49,8 +49,8 @@ func (e ExtAttr) GetFloat(key string) (float64, bool) {
 func (c *Client) NetworkObject(ref string) *NetworkObject {
 	obj := NetworkObject{}
 	obj.Object = Object{
-		_ref: ref,
-		r:    c.Network(),
+		Ref: ref,
+		r:   c.Network(),
 	}
 	return &obj
 }

--- a/object.go
+++ b/object.go
@@ -7,8 +7,8 @@ import (
 
 //Resource represents a WAPI object
 type Object struct {
-	_ref string
-	r    *Resource
+	Ref string `json:"_ref"`
+	r   *Resource
 }
 
 func (o Object) Get(opts *Options) (map[string]interface{}, error) {
@@ -92,9 +92,5 @@ func (o Object) FunctionCall(functionName string, inputFields url.Values) (map[s
 }
 
 func (o Object) objectURI() string {
-	return BASE_PATH + o._ref
-}
-
-func (o Object) Ref() string {
-	return o._ref
+	return BASE_PATH + o.Ref
 }

--- a/record_cname.go
+++ b/record_cname.go
@@ -15,8 +15,8 @@ type RecordCnameObject struct {
 func (c *Client) RecordCnameObject(ref string) *RecordCnameObject {
 	return &RecordCnameObject{
 		Object{
-			_ref: ref,
-			r:    c.RecordCname(),
+			Ref: ref,
+			r:   c.RecordCname(),
 		},
 	}
 }

--- a/record_host.go
+++ b/record_host.go
@@ -29,8 +29,8 @@ type HostIpv4Addr struct {
 func (c *Client) RecordHostObject(ref string) *RecordHostObject {
 	host := RecordHostObject{}
 	host.Object = Object{
-		_ref: ref,
-		r:    c.RecordHost(),
+		Ref: ref,
+		r:   c.RecordHost(),
 	}
 	return &host
 }

--- a/record_ptr.go
+++ b/record_ptr.go
@@ -14,8 +14,8 @@ type RecordPtrObject struct {
 func (c *Client) RecordPtrObject(ref string) *RecordPtrObject {
 	return &RecordPtrObject{
 		Object{
-			_ref: ref,
-			r:    c.RecordPtr(),
+			Ref: ref,
+			r:   c.RecordPtr(),
 		},
 	}
 }

--- a/scheduledtask.go
+++ b/scheduledtask.go
@@ -15,8 +15,8 @@ type ScheduledTaskObject struct {
 func (c *Client) ScheduledTaskObject(ref string) *ScheduledTaskObject {
 	return &ScheduledTaskObject{
 		Object{
-			_ref: ref,
-			r:    c.ScheduledTask(),
+			Ref: ref,
+			r:   c.ScheduledTask(),
 		},
 	}
 }


### PR DESCRIPTION
To easily populate _ref field in objects, it makes sense to export it so it can be unmarshalled.
