### PR TITLE
Add error handling for actually sending a request

### DIFF
--- a/infoblox.go
+++ b/infoblox.go
@@ -95,6 +95,9 @@ func (c *Client) SendRequest(method, urlStr, body string, head map[string]string
 	}
 
 	r, err = c.HttpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Error executing request: %v\n", err)
+	}
 	if r.StatusCode == 401 && c.UseCookies { // don't bother re-sending if we aren't using cookies
 		log.Printf("Re-sending request with basic auth after 401")
 		// Re-build request


### PR DESCRIPTION
SendRequest has an error that is just being ignored and causing a nil pointer dereference and resulting panic.

The actual scenario that I ran into this was using the terraform-provider-infoblox plugin where instead of specifying the host with a given protocol (i.e. https://URL_HERE), just the url was given.

The resulting error from the `c.HttpClient.Do` saying `Post URL_HERE/wapi/v1.4.1/record:a: unsupported protocol scheme ""` was causing the `r` assignment to be nil.

The line below it `r.StatusCode` was causing a nil pointer dereference and the resulting panic. This fix actually returns the error rather than just `panic`king.