### PR TITLE
Fix exclude parameters for borked infoblox API

### DIFF
--- a/network.go
+++ b/network.go
@@ -1,11 +1,6 @@
 package infoblox
 
-import (
-	"fmt"
-	"net/url"
-	"strconv"
-	"strings"
-)
+import "fmt"
 
 // https://192.168.2.200/wapidoc/objects/network.html
 func (c *Client) Network() *Resource {
@@ -59,16 +54,20 @@ func (c *Client) NetworkObject(ref string) *NetworkObject {
 //returning an array of available IP addresses.
 //You may optionally specify how many IPs you want (num) and which ones to
 //exclude from consideration (array of IPv4 addrdess strings).
+type NextAvailableIPParams struct {
+	Exclude []string `json:"exclude,omitempty"`
+	Num     int      `json:"num,omitempty"`
+}
+
 func (n NetworkObject) NextAvailableIP(num int, exclude []string) (map[string]interface{}, error) {
 	if num == 0 {
 		num = 1
 	}
 
-	v := url.Values{}
-	if exclude != nil {
-		v.Set("exclude", strings.Join(exclude, ","))
+	v := &NextAvailableIPParams{
+		Exclude: exclude,
+		Num:     num,
 	}
-	v.Set("num", strconv.Itoa(num))
 
 	out, err := n.FunctionCall("next_available_ip", v)
 	if err != nil {

--- a/object.go
+++ b/object.go
@@ -104,10 +104,13 @@ func (o Object) Delete(opts *Options) error {
 	return nil
 }
 
-func (o Object) FunctionCall(functionName string, inputFields url.Values) (map[string]interface{}, error) {
-	inputFields.Set("_function", functionName)
+func (o Object) FunctionCall(functionName string, jsonBody interface{}) (map[string]interface{}, error) {
+	data, err := json.Marshal(jsonBody)
+	if err != nil {
+		return nil, fmt.Errorf("Error sending request: %v\n", err)
+	}
 
-	resp, err := o.r.conn.SendRequest("POST", o.objectURI(), inputFields.Encode(), map[string]string{"Content-Type": "application/x-www-form-urlencoded"})
+	resp, err := o.r.conn.SendRequest("POST", fmt.Sprintf("%s?_function=%s", o.objectURI(), functionName), string(data), map[string]string{"Content-Type": "application/json"})
 	if err != nil {
 		return nil, fmt.Errorf("Error sending request: %v\n", err)
 	}


### PR DESCRIPTION
The Infoblox API appears to have a bug in it around certain function calls where parameters have to be passed via json encoded bodies rather than being form encoded:

https://community.infoblox.com/t5/Security/Using-exclude-with-next-available-ip/td-p/721

I took a look at what currently uses the FunctionCall method, and it appears to only be used in NextAvaialableIP, so this really shouldn't affect too much. Basically I made it so that for function calls you pass any struct that can be serialized into json and used json encoding for the function calls.