### PR TITLE
Add client Get and Find methods for PTR records.

### DIFF
--- a/record_ptr.go
+++ b/record_ptr.go
@@ -1,5 +1,7 @@
 package infoblox
 
+import "fmt"
+
 func (c *Client) RecordPtr() *Resource {
 	return &Resource{
 		conn:       c,
@@ -25,4 +27,33 @@ func (c *Client) RecordPtrObject(ref string) *RecordPtrObject {
 		r:   c.RecordPtr(),
 	}
 	return &ptr
+}
+
+func (c *Client) GetRecordPtr(ref string, opts *Options) (*RecordPtrObject, error) {
+	resp, err := c.RecordPtrObject(ref).get(opts)
+	if err != nil {
+		return nil, fmt.Errorf("Could not get created PTR record: %s", err)
+	}
+	var out RecordPtrObject
+	err = resp.Parse(&out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) FindRecordPtr(name string) ([]RecordPtrObject, error) {
+	field := "name"
+	conditions := []Condition{Condition{Field: &field, Value: name}}
+	resp, err := c.RecordPtr().find(conditions, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []RecordPtrObject
+	err = resp.Parse(&out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }


### PR DESCRIPTION
I'm adding PTR records to the terraform infoblox provider that @prudhvitella created and need to be able to Get them from the go-infoblox client. The code is pretty much a copy-paste of the methods in `record_a.go` and (admittedly minimally) tested with the below example code.

```
package main

import (
	"fmt"

	infoblox "github.com/fanatic/go-infoblox"
)

func main() {
	recordRef := "record:ptr/blahblah:ptrrecordtest.domain.lan/default"
	recordName := "ptrrecordtest.domain.lan"

	ib := infoblox.NewClient("https://10.0.0.10", "infobloxuser", "infobloxpassword!", false, false)

	ptr, err := ib.GetRecordPtr(recordRef, nil)
	if err != nil {
		panic(err)
	}
	fmt.Println(ptr)

	findPtr, err := ib.FindRecordPtr(recordName)
	if err != nil {
		panic(err)
	}
	fmt.Println(findPtr)
}
```

Output is:

```
$ go run main.go
2018/04/03 14:20:55 WARNING: SSL cert verification  disabled
2018/04/03 14:20:55 GET /wapi/v1.4.1/record:ptr/blahblah:ptrrecordtest.domain.lan/default?  payload:
&{{record:ptr/blahblah:ptrrecordtest.domain.lan/default <nil>}     ptrrecordtest.domain.lan 0 default}
2018/04/03 14:20:55 GET /wapi/v1.4.1/record:ptr?name=ptrrecordtest.domain.lan  payload:
[{{record:ptr/blahblah:ptrrecordtest.domain.lan/default <nil>}     ptrrecordtest.domain.lan 0 default}]
```