### PR TITLE
Upgrading WAPI version to 1.7

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	// WapiVersion specifies the version of the Infoblox REST API to target
-	WapiVersion = "1.4.1"
+	WapiVersion = "1.4.2"
 
 	// BasePath specifies the default path prefix to all WAPI actions
 	BasePath = "/wapi/v" + WapiVersion + "/"

--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	// WapiVersion specifies the version of the Infoblox REST API to target
-	WapiVersion = "1.4.2"
+	WapiVersion = "2.2.2"
 
 	// BasePath specifies the default path prefix to all WAPI actions
 	BasePath = "/wapi/v" + WapiVersion + "/"

--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	// WapiVersion specifies the version of the Infoblox REST API to target
-	WapiVersion = "2.2.2"
+	WapiVersion = "1.7"
 
 	// BasePath specifies the default path prefix to all WAPI actions
 	BasePath = "/wapi/v" + WapiVersion + "/"

--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	// WapiVersion specifies the version of the Infoblox REST API to target
-	WapiVersion = "2.2"
+	WapiVersion = "1.7"
 
 	// BasePath specifies the default path prefix to all WAPI actions
 	BasePath = "/wapi/v" + WapiVersion + "/"

--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	// WapiVersion specifies the version of the Infoblox REST API to target
-	WapiVersion = "1.7"
+	WapiVersion = "2.2"
 
 	// BasePath specifies the default path prefix to all WAPI actions
 	BasePath = "/wapi/v" + WapiVersion + "/"


### PR DESCRIPTION
Hello,

This is a pretty simple change. This changes the WAPI version from 1.4.1 to 2.2, which is the most recent version Infoblox supports now. Please let me know if there are any questions! Thanks :) 
