### PR TITLE
remove omitempty json option for boolean flags as it omits false

### DIFF
--- a/ipv4address.go
+++ b/ipv4address.go
@@ -14,7 +14,7 @@ type Ipv4addressObject struct {
 	Object
 	DHCPClientIdentifier string   `json:"dhcp_client_identifier,omitempty"`
 	IPAddress            string   `json:"ip_address,omitempty"`
-	IsConflict           bool     `json:"is_conflict,omitempty"`
+	IsConflict           bool     `json:"is_conflict"`
 	LeaseState           string   `json:"lease_state,omitempty"`
 	MACAddress           string   `json:"mac_address,omitempty"`
 	Names                []string `json:"names,omitempty"`

--- a/record_host.go
+++ b/record_host.go
@@ -15,7 +15,7 @@ func (c *Client) RecordHost() *Resource {
 type RecordHostObject struct {
 	Object
 	Comment         string         `json:"comment,omitempty"`
-	ConfigureForDNS bool           `json:"configure_for_dns,omitempty"`
+	ConfigureForDNS bool           `json:"configure_for_dns"`
 	Ipv4Addrs       []HostIpv4Addr `json:"ipv4addrs,omitempty"`
 	Ipv6Addrs       []HostIpv6Addr `json:"ipv6addrs,omitempty"`
 	Name            string         `json:"name,omitempty"`
@@ -26,7 +26,7 @@ type RecordHostObject struct {
 // HostIpv4Addr is an ipv4 address for a HOST record
 type HostIpv4Addr struct {
 	Object           `json:"-"`
-	ConfigureForDHCP bool   `json:"configure_for_dhcp,omitempty"`
+	ConfigureForDHCP bool   `json:"configure_for_dhcp"`
 	Host             string `json:"host,omitempty"`
 	Ipv4Addr         string `json:"ipv4addr,omitempty"`
 	MAC              string `json:"mac,omitempty"`
@@ -35,7 +35,7 @@ type HostIpv4Addr struct {
 // HostIpv6Addr is an ipv6 address for a HOST record
 type HostIpv6Addr struct {
 	Object           `json:"-"`
-	ConfigureForDHCP bool   `json:"configure_for_dhcp,omitempty"`
+	ConfigureForDHCP bool   `json:"configure_for_dhcp"`
 	Host             string `json:"host,omitempty"`
 	Ipv6Addr         string `json:"ipv6addr,omitempty"`
 	MAC              string `json:"mac,omitempty"`


### PR DESCRIPTION
The Go JSON library considers a `false` value to be empty and omits it, but we want it to be present when setting it to false. 