### PR TITLE
Add initial Network Container records collection support

### DIFF
--- a/network_container.go
+++ b/network_container.go
@@ -1,0 +1,17 @@
+package infoblox
+
+// NetworkContainer returns an Infoblox Network Container resource.
+func (c *Client) NetworkContainer() *Resource {
+	return &Resource{
+		conn:       c,
+		wapiObject: "networkcontainer",
+	}
+}
+
+// NetworkContainerObject defines the Infoblox Network Container object's fields.
+type NetworkContainerObject struct {
+	Object
+	Comment  string  `json:"comment,omitempty"`
+	Network  string  `json:"network,omitempty"`
+	ExtAttrs ExtAttr `json:"extattrs,omitempty"`
+}


### PR DESCRIPTION
This merge request features the initial support for gathering data of Network Container Objects from Infoblox.