### PR TITLE
Add function to allow making new Resource objects explicitly

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -18,6 +18,16 @@ type Resource struct {
 	wapiObject string
 }
 
+// NewResource creates new resource object from the passed parameters.
+// As Infoblox contains hundreds of different objects, this function
+// will allow the users to adopt new ones vary easy.
+func NewResource(c *Client, wapiObject string) *Resource {
+	return &Resource{
+		conn:       c,
+		wapiObject: wapiObject,
+	}
+}
+
 // Options represents the Options to be passed to the Infoblox WAPI
 type Options struct {
 	//The maximum number of objects to be returned.  If set to a negative


### PR DESCRIPTION
The function featured in this Pull request will allow users of the library to define their own resource objects very easy. The main reason why we need this function is that we want to query the Infoblox instance schema ( https://1.2.3.4/wapi/v1.0/?_schema ) for that reason we need a resource with wapiObject="", but adding a dedicated Resource object just for this does not look good. The result that we would like to have is ( sample from https://ipam.illinois.edu/wapidoc/index.html#objects ) :
```
{
  "requested_version": "1.0",
  "supported_objects": [
            "ipv4address",
            "ipv6address",
            "ipv6network",
            "ipv6networkcontainer",
            "ipv6range",
            "macfilteraddress",
            "network"
  ],
  "supported_versions": ["1.0", "1.1", "1.2", "1.2.1"]
}
```